### PR TITLE
feat: Make default file extension changeable

### DIFF
--- a/src/Notepads/Core/NotepadsCore.cs
+++ b/src/Notepads/Core/NotepadsCore.cs
@@ -103,11 +103,12 @@
             var textFile = new TextFile(string.Empty,
                 AppSettingsService.EditorDefaultEncoding,
                 AppSettingsService.EditorDefaultLineEnding);
+            var fileName = fileNamePlaceholder + AppSettingsService.EditorDefaultFileExtension;
             var newEditor = CreateTextEditor(
                 Guid.NewGuid(),
                 textFile,
                 null,
-                fileNamePlaceholder);
+                fileName);
             OpenTextEditor(newEditor);
         }
 

--- a/src/Notepads/Services/AppSettingsService.cs
+++ b/src/Notepads/Services/AppSettingsService.cs
@@ -208,6 +208,18 @@
             }
         }
 
+        private static string _editorDefaultFileExtension;
+
+        public static string EditorDefaultFileExtension
+        {
+            get => _editorDefaultFileExtension;
+            set
+            {
+                _editorDefaultFileExtension = value;
+                ApplicationSettingsStore.Write(SettingsKey.EditorDefaultFileExtensionStr, value);
+            }
+        }
+
         private static bool _showStatusBar;
 
         public static bool ShowStatusBar
@@ -306,11 +318,25 @@
 
             InitializeSearchEngineSettings();
 
+            InitializeFileExtensionSettings();
+
             InitializeStatusBarSettings();
 
             InitializeSessionSnapshotSettings();
 
             InitializeAppOpeningPreferencesSettings();
+        }
+
+        private static void InitializeFileExtensionSettings()
+        {
+            if (ApplicationSettingsStore.Read(SettingsKey.EditorDefaultFileExtensionStr) is string fileExtension)
+            {
+                _editorDefaultFileExtension = fileExtension;
+            }
+            else
+            {
+                _editorDefaultFileExtension = ".md";
+            }
         }
 
         private static void InitializeStatusBarSettings()

--- a/src/Notepads/Settings/SettingsKey.cs
+++ b/src/Notepads/Settings/SettingsKey.cs
@@ -30,6 +30,7 @@
         internal static string EditorDefaultTabIndentsInt = "EditorDefaultTabIndentsInt";
         internal static string EditorDefaultSearchEngineStr = "EditorDefaultSearchUrlStr";
         internal static string EditorCustomMadeSearchUrlStr = "EditorCustomMadeSearchUrlStr";
+        internal static string EditorDefaultFileExtensionStr = "EditorDefaultFileExtensionStr";
         internal static string EditorShowStatusBarBool = "EditorShowStatusBarBool";
         internal static string EditorEnableSessionBackupAndRestoreBool = "EditorEnableSessionBackupAndRestoreBool";
         internal static string EditorHighlightMisspelledWordsBool = "EditorHighlightMisspelledWordsBool";

--- a/src/Notepads/Strings/ar-YE/Resources.resw
+++ b/src/Notepads/Strings/ar-YE/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>بلا عنوان.txt</value>
+    <value>بلا عنوان</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/ar-YE/Settings.resw
+++ b/src/Notepads/Strings/ar-YE/Settings.resw
@@ -421,4 +421,16 @@
     <value>الإفتراضي في النظام</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/bg-BG/Resources.resw
+++ b/src/Notepads/Strings/bg-BG/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Нов документ.txt</value>
+    <value>Нов документ</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/bg-BG/Settings.resw
+++ b/src/Notepads/Strings/bg-BG/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/cs-CZ/Resources.resw
+++ b/src/Notepads/Strings/cs-CZ/Resources.resw
@@ -370,7 +370,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Untitled.txt</value>
+    <value>Untitled</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_FileModifiedOutsideIndicator_ToolTip" xml:space="preserve">

--- a/src/Notepads/Strings/cs-CZ/Settings.resw
+++ b/src/Notepads/Strings/cs-CZ/Settings.resw
@@ -421,4 +421,16 @@
     <value>Výchozí systémový</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/de-CH/Resources.resw
+++ b/src/Notepads/Strings/de-CH/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Unbenannt.txt</value>
+    <value>Unbenannt</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/de-CH/Settings.resw
+++ b/src/Notepads/Strings/de-CH/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/de-DE/Resources.resw
+++ b/src/Notepads/Strings/de-DE/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Unbenannt.txt</value>
+    <value>Unbenannt</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/de-DE/Settings.resw
+++ b/src/Notepads/Strings/de-DE/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/en-US/Resources.resw
+++ b/src/Notepads/Strings/en-US/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Untitled.txt</value>
+    <value>Untitled</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/en-US/Settings.resw
+++ b/src/Notepads/Strings/en-US/Settings.resw
@@ -421,4 +421,28 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/en-US/Settings.resw
+++ b/src/Notepads/Strings/en-US/Settings.resw
@@ -433,16 +433,4 @@
     <value>Default File Extension</value>
     <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
   </data>
-  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
-    <value>Default File Extension Settings</value>
-    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
-  </data>
-  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
-    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
-    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
-  </data>
-  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
-    <value>Default File Extension</value>
-    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
-  </data>
 </root>

--- a/src/Notepads/Strings/es-ES/Resources.resw
+++ b/src/Notepads/Strings/es-ES/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Nuevo Documento.txt</value>
+    <value>Nuevo Documento</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/es-ES/Settings.resw
+++ b/src/Notepads/Strings/es-ES/Settings.resw
@@ -421,4 +421,16 @@
     <value>Valor predeterminado del sistema</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/fi-FI/Resources.resw
+++ b/src/Notepads/Strings/fi-FI/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Nimetön.txt</value>
+    <value>Nimetön</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/fi-FI/Settings.resw
+++ b/src/Notepads/Strings/fi-FI/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/fr-FR/Resources.resw
+++ b/src/Notepads/Strings/fr-FR/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Nouveau Document.txt</value>
+    <value>Nouveau Document</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/fr-FR/Settings.resw
+++ b/src/Notepads/Strings/fr-FR/Settings.resw
@@ -421,4 +421,16 @@
     <value>Langue du système</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/hi-IN/Resources.resw
+++ b/src/Notepads/Strings/hi-IN/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>अनामांकित.txt</value>
+    <value>अनामांकित</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/hi-IN/Settings.resw
+++ b/src/Notepads/Strings/hi-IN/Settings.resw
@@ -421,4 +421,16 @@
     <value>व्यवस्था निर्धारित</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/hr-HR/Resources.resw
+++ b/src/Notepads/Strings/hr-HR/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Bezimeno.txt</value>
+    <value>Bezimeno</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/hr-HR/Settings.resw
+++ b/src/Notepads/Strings/hr-HR/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/hu-HU/Resources.resw
+++ b/src/Notepads/Strings/hu-HU/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Névtelen.txt</value>
+    <value>Névtelen</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/hu-HU/Settings.resw
+++ b/src/Notepads/Strings/hu-HU/Settings.resw
@@ -421,4 +421,16 @@
     <value>Rendszer alapértelmezett</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/it-IT/Resources.resw
+++ b/src/Notepads/Strings/it-IT/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Senza titolo.txt</value>
+    <value>Senza titolo</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/it-IT/Settings.resw
+++ b/src/Notepads/Strings/it-IT/Settings.resw
@@ -421,4 +421,16 @@
     <value>Predefinita di sistema</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/ja-JP/Resources.resw
+++ b/src/Notepads/Strings/ja-JP/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>無題.txt</value>
+    <value>無題</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/ja-JP/Settings.resw
+++ b/src/Notepads/Strings/ja-JP/Settings.resw
@@ -421,4 +421,16 @@
     <value>システム既定</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/ka-GE/Resources.resw
+++ b/src/Notepads/Strings/ka-GE/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>უსახელო.txt</value>
+    <value>უსახელო</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/ka-GE/Settings.resw
+++ b/src/Notepads/Strings/ka-GE/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/ko-KR/Resources.resw
+++ b/src/Notepads/Strings/ko-KR/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>새 텍스트 문서.txt</value>
+    <value>새 텍스트 문서</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/ko-KR/Settings.resw
+++ b/src/Notepads/Strings/ko-KR/Settings.resw
@@ -421,4 +421,16 @@
     <value>시스템 </value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/or-IN/Resources.resw
+++ b/src/Notepads/Strings/or-IN/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>ଆଖ୍ୟାବିହୀନ.txt</value>
+    <value>ଆଖ୍ୟାବିହୀନ</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/or-IN/Settings.resw
+++ b/src/Notepads/Strings/or-IN/Settings.resw
@@ -421,4 +421,16 @@
     <value>ବ୍ୟବସ୍ଥା ସ୍ଥିତ</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/pl-PL/Resources.resw
+++ b/src/Notepads/Strings/pl-PL/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Bez tytułu.txt</value>
+    <value>Bez tytułu</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/pl-PL/Settings.resw
+++ b/src/Notepads/Strings/pl-PL/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/pt-BR/Resources.resw
+++ b/src/Notepads/Strings/pt-BR/Resources.resw
@@ -350,7 +350,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Sem título.txt</value>
+    <value>Sem título</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/pt-BR/Settings.resw
+++ b/src/Notepads/Strings/pt-BR/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/pt-PT/Resources.resw
+++ b/src/Notepads/Strings/pt-PT/Resources.resw
@@ -350,7 +350,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Sem título.txt</value>
+    <value>Sem título</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/pt-PT/Settings.resw
+++ b/src/Notepads/Strings/pt-PT/Settings.resw
@@ -421,4 +421,16 @@
     <value>Sistema Padrão</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/ru-RU/Resources.resw
+++ b/src/Notepads/Strings/ru-RU/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Безымянный.txt</value>
+    <value>Безымянный</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/ru-RU/Settings.resw
+++ b/src/Notepads/Strings/ru-RU/Settings.resw
@@ -421,4 +421,16 @@
     <value>Системный по умолчанию</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/sr-Latn/Resources.resw
+++ b/src/Notepads/Strings/sr-Latn/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Bez naslova.txt</value>
+    <value>Bez naslova</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/sr-Latn/Settings.resw
+++ b/src/Notepads/Strings/sr-Latn/Settings.resw
@@ -421,4 +421,16 @@
     <value>Sistemski podrazumevani</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/sr-cyrl/Resources.resw
+++ b/src/Notepads/Strings/sr-cyrl/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Без наслова.txt</value>
+    <value>Без наслова</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/sr-cyrl/Settings.resw
+++ b/src/Notepads/Strings/sr-cyrl/Settings.resw
@@ -421,4 +421,16 @@
     <value>Системски подразумевани</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/tr-TR/Resources.resw
+++ b/src/Notepads/Strings/tr-TR/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Yeni Belge.txt</value>
+    <value>Yeni Belge</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/tr-TR/Settings.resw
+++ b/src/Notepads/Strings/tr-TR/Settings.resw
@@ -421,4 +421,16 @@
     <value>Sistem Varsayılanı</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/uk-UA/Resources.resw
+++ b/src/Notepads/Strings/uk-UA/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>Без імені.txt</value>
+    <value>Без імені</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/uk-UA/Settings.resw
+++ b/src/Notepads/Strings/uk-UA/Settings.resw
@@ -421,4 +421,16 @@
     <value>З налаштувань системи</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/zh-CN/Resources.resw
+++ b/src/Notepads/Strings/zh-CN/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>新建文本文档.txt</value>
+    <value>新建文本文档</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/zh-CN/Settings.resw
+++ b/src/Notepads/Strings/zh-CN/Settings.resw
@@ -421,4 +421,16 @@
     <value>使用系统默认语言</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Strings/zh-TW/Resources.resw
+++ b/src/Notepads/Strings/zh-TW/Resources.resw
@@ -354,7 +354,7 @@
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
-    <value>未命名.txt</value>
+    <value>未命名</value>
     <comment>TextEditor: Default file name for new document.</comment>
   </data>
   <data name="TextEditor_LineColumnIndicator_FullText" xml:space="preserve">

--- a/src/Notepads/Strings/zh-TW/Settings.resw
+++ b/src/Notepads/Strings/zh-TW/Settings.resw
@@ -421,4 +421,16 @@
     <value>System Default</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_Title.Text" xml:space="preserve">
+    <value>Default File Extension Settings</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings Title display text.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport.Text" xml:space="preserve">
+    <value>*file extension must be in the format .{0} and must not contain any invalid characters</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension when entered text is not a valid format.</comment>
+  </data>
+  <data name="AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension.Header" xml:space="preserve">
+    <value>Default File Extension</value>
+    <comment>AdvancedPage DefaultFileExtensionSettings DefaultFileExtension header text.</comment>
+  </data>
 </root>

--- a/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml
+++ b/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml
@@ -27,6 +27,26 @@
             VerticalScrollMode="Auto">
             <StackPanel HorizontalAlignment="Left" Margin="0,0,0,40">
                 <TextBlock
+                    x:Uid="/Settings/AdvancedPage_DefaultFileExtensionSettings_Title"
+                    Style="{StaticResource CompactSubtitleTextBlockStyle}"
+                    Margin="0,15,0,0"
+                    FontWeight="Normal"/>
+                <StackPanel Margin="0,10,0,0">
+                    <TextBox x:Uid="/Settings/AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtension"
+                             Style="{StaticResource TransparentTextBoxStyle}"
+                             BorderThickness="0"
+                             x:Name="DefaultFileExtension"
+                             PlaceholderText=".md"
+                             IsSpellCheckEnabled="False"
+                             TextChanged="DefaultFileExtension_TextChanged"
+                             LostFocus="DefaultFileExtension_LostFocus"/>
+                    <TextBlock x:Name="DefaultFileExtensionErrorReport"
+                               x:Uid="/Settings/AdvancedPage_DefaultFileExtensionSettings_DefaultFileExtensionErrorReport"
+                               Style="{ThemeResource DescriptionTextBlockStyle}"
+                               Foreground="Red"
+                               Visibility="Collapsed"/>
+                </StackPanel>
+                <TextBlock
                     x:Uid="/Settings/AdvancedPage_StatusBarSettings_Title"
                     Style="{StaticResource CompactSubtitleTextBlockStyle}"
                     Margin="0,15,0,0"

--- a/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
+++ b/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
@@ -44,8 +44,18 @@
             LanguagePicker.SelectedItem = SupportedLanguages.FirstOrDefault(language => language.ID == ApplicationLanguages.PrimaryLanguageOverride);
             RestartPrompt.Visibility = LanguageUtility.CurrentLanguageID == ApplicationLanguages.PrimaryLanguageOverride ? Visibility.Collapsed : Visibility.Visible;
 
+            InitializeFileExtensionSettings();
+
             Loaded += AdvancedSettings_Loaded;
             Unloaded += AdvancedSettings_Unloaded;
+        }
+
+        private void InitializeFileExtensionSettings()
+        {
+            if (!string.IsNullOrEmpty(AppSettingsService.EditorDefaultFileExtension))
+            {
+                DefaultFileExtension.Text = AppSettingsService.EditorDefaultFileExtension;
+            }
         }
 
         private void AdvancedSettings_Loaded(object sender, RoutedEventArgs e)
@@ -64,6 +74,18 @@
             EnableSessionSnapshotToggleSwitch.Toggled -= EnableSessionBackupAndRestoreToggleSwitch_Toggled;
             AlwaysOpenNewWindowToggleSwitch.Toggled -= AlwaysOpenNewWindowToggleSwitch_Toggled;
             LanguagePicker.SelectionChanged -= LanguagePicker_SelectionChanged;
+        }
+
+        private void DefaultFileExtension_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            AppSettingsService.EditorDefaultFileExtension = DefaultFileExtension.Text;
+            DefaultFileExtensionErrorReport.Visibility = FileSystemUtility.IsFilenameValid(DefaultFileExtension.Text, out _) ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void DefaultFileExtension_LostFocus(object sender, RoutedEventArgs e)
+        {
+            DefaultFileExtensionErrorReport.Visibility = FileSystemUtility.IsFilenameValid(DefaultFileExtension.Text, out _) ? Visibility.Collapsed : Visibility.Visible;
+            AppSettingsService.EditorDefaultFileExtension = FileSystemUtility.IsFilenameValid(DefaultFileExtension.Text, out _) ? DefaultFileExtension.Text : ".md";
         }
 
         private void EnableSmartCopyToggleSwitch_Toggled(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Addresses #1046, which requested the changing of the default file extension to .md, which I added along with the ability to change the default file extension in the Advanced settings tab.

![image](https://user-images.githubusercontent.com/29359076/160432711-f0386241-cd4e-4bb9-8b36-6d5c802e8afc.png)


## PR Type

What kind of change does this PR introduce?

- Feature

## Other information

It's probably not the best, however I wanted to change it for myself and decided to open a PR for it.
I only speak English, but I have added the needed options in all the Settings.resw files, along with removing the file extension from Resources.resw. I tried to adhere to the code already present, however a couple things may need changing as I am not used to UWP.