### PR TITLE
lang: Update french translation

### DIFF
--- a/src/Notepads/Strings/fr-FR/Settings.resw
+++ b/src/Notepads/Strings/fr-FR/Settings.resw
@@ -298,13 +298,11 @@
     <comment>AdvancedPage SessionSnapshotSettings Description display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OffContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp; 
-la restauration de session</value>
+    <value>Activer la sauvegarde &amp; la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch On display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OnContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp; 
-la restauration de session</value>
+    <value>Activer la sauvegarde &amp; la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_Title.Text" xml:space="preserve">
@@ -424,13 +422,11 @@ la restauration de session</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_ExitWhenLastTabClosedToggleSwitch.OffContent" xml:space="preserve">
-    <value>Quitter l'application à la 
-fermeture du dernier onglet</value>
+    <value>Quitter l'application à la fermeture du dernier onglet</value>
     <comment>AdvancedPage AppLifecyclePreferenceSettings ExitingLastTabClosesWindowToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_ExitWhenLastTabClosedToggleSwitch.OnContent" xml:space="preserve">
-    <value>Quitter l'application à la 
-fermeture du dernier onglet</value>
+    <value>Quitter l'application à la fermeture du dernier onglet</value>
     <comment>AdvancedPage AppLifecyclePreferenceSettings ExitingLastTabClosesWindowToggleSwitch On display text.</comment>
   </data>
 </root>

--- a/src/Notepads/Strings/fr-FR/Settings.resw
+++ b/src/Notepads/Strings/fr-FR/Settings.resw
@@ -298,11 +298,13 @@
     <comment>AdvancedPage SessionSnapshotSettings Description display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OffContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp; la restauration de session</value>
+    <value>Activer la sauvegarde &amp; 
+la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch On display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OnContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp; la restauration de session</value>
+    <value>Activer la sauvegarde &amp; 
+la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_Title.Text" xml:space="preserve">
@@ -422,11 +424,13 @@
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_ExitWhenLastTabClosedToggleSwitch.OffContent" xml:space="preserve">
-    <value>Quitter l'application à la fermeture du dernier onglet</value>
+    <value>Quitter l'application à la 
+fermeture du dernier onglet</value>
     <comment>AdvancedPage AppLifecyclePreferenceSettings ExitingLastTabClosesWindowToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_ExitWhenLastTabClosedToggleSwitch.OnContent" xml:space="preserve">
-    <value>Quitter l'application à la fermeture du dernier onglet</value>
+    <value>Quitter l'application à la 
+fermeture du dernier onglet</value>
     <comment>AdvancedPage AppLifecyclePreferenceSettings ExitingLastTabClosesWindowToggleSwitch On display text.</comment>
   </data>
 </root>

--- a/src/Notepads/Strings/fr-FR/Settings.resw
+++ b/src/Notepads/Strings/fr-FR/Settings.resw
@@ -422,11 +422,11 @@
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_ExitWhenLastTabClosedToggleSwitch.OffContent" xml:space="preserve">
-    <value>Exit app when closing last tab</value>
+    <value>Quitter l'application à la fermeture du dernier onglet</value>
     <comment>AdvancedPage AppLifecyclePreferenceSettings ExitingLastTabClosesWindowToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_ExitWhenLastTabClosedToggleSwitch.OnContent" xml:space="preserve">
-    <value>Exit app when closing last tab</value>
+    <value>Quitter l'application à la fermeture du dernier onglet</value>
     <comment>AdvancedPage AppLifecyclePreferenceSettings ExitingLastTabClosesWindowToggleSwitch On display text.</comment>
   </data>
 </root>

--- a/src/Notepads/Strings/fr-FR/Settings.resw
+++ b/src/Notepads/Strings/fr-FR/Settings.resw
@@ -126,7 +126,7 @@
     <comment>AboutPage Disclaimer Content display text. (The MIT License Disclaimer)</comment>
   </data>
   <data name="AboutPage_Disclaimer_Title.Text" xml:space="preserve">
-    <value>Avertissement</value>
+    <value>Avis de non-responsabilité</value>
     <comment>AboutPage Disclaimer Title display text.</comment>
   </data>
   <data name="AboutPage_NotepadsShortDescription.Text" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>AboutPage Notepads IssueAndFeatureRequests Title display text.</comment>
   </data>
   <data name="AboutPage_Notepads_SourceCodeTitle.Text" xml:space="preserve">
-    <value>Code source est disponible sur GitHub :</value>
+    <value>Code source disponible sur GitHub :</value>
     <comment>AboutPage Notepads SourceCode Title display text.</comment>
   </data>
   <data name="AboutPage_Notepads_WebsiteTitle.Text" xml:space="preserve">


### PR DESCRIPTION
## PR Type

Update french translation.

However, the French translation takes up more space than the English one and overflows the side panel:

![French translation updated in advanced settings panel](https://user-images.githubusercontent.com/11057437/218196567-ba49548e-4f07-4838-873d-f5de538e15d0.png)

Should a line break be added? Like below? (Same problem for the "_Enable session snapshot_" setting.)

![French translation with new line in advanced settings panel](https://user-images.githubusercontent.com/11057437/218195795-e2515d5e-caa7-4891-bdc1-795a9b15860c.png)