### PR TITLE
feat: add markdown file to shell new context menu

### DIFF
--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -284,6 +284,7 @@
   <ItemGroup>
     <None Include="Package.StoreAssociation.xml" />
     <Content Include="Properties\Default.rd.xml" />
+    <Content Include="Resource\Markdown Document.md" />
     <Content Include="Resource\MiddleClickScrolling-CursorType.res" />
     <Content Include="Resource\Text Document.txt" />
   </ItemGroup>

--- a/src/Notepads/Package.appxmanifest
+++ b/src/Notepads/Package.appxmanifest
@@ -82,7 +82,7 @@
               <uap:FileType>.cfg</uap:FileType>
               <uap:FileType>.config</uap:FileType>
               <uap:FileType>.cnf</uap:FileType>
-              <uap:FileType>.conf</uap:FileType>
+              <uap:FileType ContentType="text/plain">.conf</uap:FileType>
               <uap:FileType>.properties</uap:FileType>
               <uap:FileType>.directory</uap:FileType>
             </uap:SupportedFileTypes>
@@ -174,7 +174,7 @@
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="xml">
             <uap:SupportedFileTypes>
-              <uap:FileType>.xml</uap:FileType>
+              <uap:FileType ContentType="application/xml">.xml</uap:FileType>
               <uap:FileType>.xsd</uap:FileType>
               <uap:FileType>.ascx</uap:FileType>
               <uap:FileType>.atom</uap:FileType>
@@ -191,8 +191,8 @@
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="html">
             <uap:SupportedFileTypes>
-              <uap:FileType>.html</uap:FileType>
-              <uap:FileType>.htm</uap:FileType>
+              <uap:FileType ContentType="text/html">.html</uap:FileType>
+              <uap:FileType ContentType="text/html">.htm</uap:FileType>
               <uap:FileType>.shtml</uap:FileType>
               <uap:FileType>.xhtml</uap:FileType>
               <uap:FileType>.mdoc</uap:FileType>
@@ -229,7 +229,7 @@
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="css">
             <uap:SupportedFileTypes>
-              <uap:FileType>.css</uap:FileType>
+              <uap:FileType ContentType="text/css">.css</uap:FileType>
               <uap:FileType>.scss</uap:FileType>
             </uap:SupportedFileTypes>
             <uap:DisplayName>ms-resource:Manifest/CssFileDisplayName</uap:DisplayName>
@@ -781,7 +781,7 @@
           <uap:FileTypeAssociation Name="diff">
             <uap:SupportedFileTypes>
               <uap:FileType>.patch</uap:FileType>
-              <uap:FileType>.diff</uap:FileType>
+              <uap:FileType ContentType="text/plain">.diff</uap:FileType>
               <uap:FileType>.rej</uap:FileType>
             </uap:SupportedFileTypes>
             <uap:DisplayName>ms-resource:Manifest/DiffFileDisplayName</uap:DisplayName>
@@ -1045,7 +1045,7 @@
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="m3u">
             <uap:SupportedFileTypes>
-              <uap:FileType>.m3u</uap:FileType>
+              <uap:FileType ContentType="audio/x-mpegurl">.m3u</uap:FileType>
               <uap:FileType>.m3u8</uap:FileType>
             </uap:SupportedFileTypes>
             <uap:DisplayName>ms-resource:Manifest/M3uFileDisplayName</uap:DisplayName>
@@ -1116,7 +1116,7 @@
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="xsl">
             <uap:SupportedFileTypes>
-              <uap:FileType>.xsl</uap:FileType>
+              <uap:FileType ContentType="application/xml">.xsl</uap:FileType>
             </uap:SupportedFileTypes>
             <uap:DisplayName>ms-resource:Manifest/XslFileDisplayName</uap:DisplayName>
             <uap:Logo>Assets\FileIcons\file.png</uap:Logo>

--- a/src/Notepads/Package.appxmanifest
+++ b/src/Notepads/Package.appxmanifest
@@ -104,7 +104,9 @@
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="markdown">
             <uap:SupportedFileTypes>
-              <uap:FileType ContentType="text/plain">.md</uap:FileType>
+              <uap:FileType ContentType="text/plain"
+                            uap4:ShellNewDisplayName="ms-resource:Manifest/MarkdownFileDisplayName"
+                            uap4:ShellNewFileName="Resource\Markdown Document.md">.md</uap:FileType>
               <uap:FileType ContentType="text/plain">.markdown</uap:FileType>
               <uap:FileType ContentType="text/plain">.mkd</uap:FileType>
               <uap:FileType ContentType="text/plain">.mdwn</uap:FileType>


### PR DESCRIPTION
Add create blank .md file to the ContextMenu new submenu. Also added a couple of ContentTypes.

## PR Type
What kind of change does this PR introduce?

- Feature
![New submenu on Windows 10](https://github.com/0x7c13/Notepads/assets/698155/237c939d-a72f-4900-9fa3-ee59bad01dcc)

## Other information
Reused the FileDisplayName for the NewDisplayName. Only tested on Windows 10 but it should be fine on 11.