### PR TITLE
Deprecate Microsoft.AppCenter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,8 +282,7 @@ jobs:
           /p:AppxBundlePlatforms=$env:APPX_BUNDLE_PLATFORMS `
           /p:AppxPackageDir=$env:ARTIFACTS_DIR `
           /p:PackageCertificateKeyFile=$env:PACKAGE_CERTIFICATE_KEYFILE `
-          /p:PackageCertificatePassword=$env:PACKAGE_CERTIFICATE_PASSWORD `
-          /p:AppCenterSecret=$env:APP_CENTER_SECRET
+          /p:PackageCertificatePassword=$env:PACKAGE_CERTIFICATE_PASSWORD
         env:
           PLATFORM: x64
           UAP_APPX_PACKAGE_BUILD_MODE: StoreUpload

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,7 +8,9 @@ If you choose to use this app, then you agree to the collection and use of infor
 
 ### Information Collection and Use  
 For a better experience while using this app, certain usage data and errors are collected for identifying issues or improving the user experience of the app. *[Visual Studio AppCenter](https://visualstudio.microsoft.com/app-center/)* analytics service is used in this app to collect basic usage data plus some minimum telemetry to help debug runtime errors. See thread [#334](https://github.com/0x7c13/Notepads/issues/334) for more details.
-The app does NOT use third party services that may collect information used to identify you. 
+The app does NOT use third party services that may collect information used to identify you.
+
+Note: Visual Studio App Center is scheduled for retirement on March 31, 2025. Notepads v1.5.6.0+ starts to use Microsoft Store Services SDK to log non-privacy usage data and errors.
 
 ### Data Security  
 We value your trust in providing us your Personal Information, thus we are striving to use commercially acceptable means of protecting it. But remember that no method of transmission over the internet, or method of electronic storage is 100% secure and reliable, and we cannot guarantee its absolute security.

--- a/src/Notepads.Controls/Notepads.Controls.csproj
+++ b/src/Notepads.Controls/Notepads.Controls.csproj
@@ -290,7 +290,7 @@
       <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Win2D.uwp">
-      <Version>1.27.1</Version>
+      <Version>1.28.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -10,9 +10,6 @@ namespace Notepads
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.AppCenter;
-    using Microsoft.AppCenter.Analytics;
-    using Microsoft.AppCenter.Crashes;
     using Microsoft.Toolkit.Uwp.Helpers;
     using Notepads.Services;
     using Notepads.Settings;
@@ -100,19 +97,6 @@ namespace Notepads
                 Window.Current.Content = rootFrame;
                 rootFrameCreated = true;
 
-                try
-                {
-                    if (!string.IsNullOrEmpty(AppCenterSecret))
-                    {
-                        var services = new Type[] { typeof(Crashes), typeof(Analytics) };
-                        AppCenter.Start(AppCenterSecret, services);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LoggingService.LogError($"[{nameof(App)}] Failed to start AppCenter: {ex.Message}");
-                }
-
                 ThemeSettingsService.Initialize();
                 AppSettingsService.Initialize();
             }
@@ -136,7 +120,7 @@ namespace Notepads
             };
 
             LoggingService.LogInfo($"[{nameof(App)}] Launch settings: \n{string.Join("\n", appLaunchSettings.Select(x => x.Key + "=" + x.Value).ToArray())}.");
-            Analytics.TrackEvent("AppLaunch_Settings", appLaunchSettings);
+            AnalyticsService.TrackEvent("AppLaunch_Settings", appLaunchSettings);
 
             var appLaunchEditorSettings = new Dictionary<string, string>()
             {
@@ -154,7 +138,7 @@ namespace Notepads
             };
 
             LoggingService.LogInfo($"[{nameof(App)}] Editor settings: \n{string.Join("\n", appLaunchEditorSettings.Select(x => x.Key + "=" + x.Value).ToArray())}.");
-            Analytics.TrackEvent("AppLaunch_Editor_Settings", appLaunchEditorSettings);
+            AnalyticsService.TrackEvent("AppLaunch_Editor_Settings", appLaunchEditorSettings);
 
             try
             {
@@ -167,8 +151,8 @@ namespace Notepads
                     { "Message", ex?.Message },
                     { "Exception", ex?.ToString() },
                 };
-                Analytics.TrackEvent("AppFailedToActivate", diagnosticInfo);
-                Crashes.TrackError(ex, diagnosticInfo);
+                AnalyticsService.TrackEvent("AppFailedToActivate", diagnosticInfo);
+                AnalyticsService.TrackError(ex, diagnosticInfo);
                 throw;
             }
 
@@ -224,7 +208,7 @@ namespace Notepads
         {
             var exception = new Exception($"[{nameof(App)}] Failed to load Page: {e.SourcePageType.FullName} Exception: {e.Exception.Message}");
             LoggingService.LogException(exception);
-            Analytics.TrackEvent("FailedToLoadPage", new Dictionary<string, string>()
+            AnalyticsService.TrackEvent("FailedToLoadPage", new Dictionary<string, string>()
             {
                 { "Page", e.SourcePageType.FullName },
                 { "Exception", e.Exception.Message }
@@ -277,15 +261,8 @@ namespace Notepads
                 { "IsGameBarWidget", IsGameBarWidget.ToString() }
             };
 
-            var attachment = ErrorAttachmentLog.AttachmentWithText(
-                $"Exception: {e.Exception}, " +
-                $"Message: {e.Message}, " +
-                $"InnerException: {e.Exception?.InnerException}, " +
-                $"InnerExceptionMessage: {e.Exception?.InnerException?.Message}",
-                "UnhandledException");
-
-            Analytics.TrackEvent("OnUnhandledException", diagnosticInfo);
-            Crashes.TrackError(e.Exception, diagnosticInfo, attachment);
+            AnalyticsService.TrackEvent("OnUnhandledException", diagnosticInfo);
+            AnalyticsService.TrackError(e.Exception, diagnosticInfo);
 
             // suppress and handle it manually.
             e.Handled = true;
@@ -305,15 +282,8 @@ namespace Notepads
                 { "InnerExceptionMessage", e.Exception?.InnerException?.Message }
             };
 
-            var attachment = ErrorAttachmentLog.AttachmentWithText(
-                $"Exception: {e.Exception}, " +
-                $"Message: {e.Exception?.Message}, " +
-                $"InnerException: {e.Exception?.InnerException}, " +
-                $"InnerExceptionMessage: {e.Exception?.InnerException?.Message}",
-                "UnobservedException");
-
-            Analytics.TrackEvent("OnUnobservedException", diagnosticInfo);
-            Crashes.TrackError(e.Exception, diagnosticInfo, attachment);
+            AnalyticsService.TrackEvent("OnUnobservedException", diagnosticInfo);
+            AnalyticsService.TrackError(e.Exception, diagnosticInfo);
 
             // suppress and handle it manually.
             e.SetObserved();

--- a/src/Notepads/AppCenterSecret.cs
+++ b/src/Notepads/AppCenterSecret.cs
@@ -1,7 +1,0 @@
-﻿namespace Notepads
-{
-    public sealed partial class App
-    {
-        private const string AppCenterSecret = null;
-    }
-}

--- a/src/Notepads/Brushes/HostBackdropAcrylicBrush.cs
+++ b/src/Notepads/Brushes/HostBackdropAcrylicBrush.cs
@@ -22,11 +22,11 @@ namespace Notepads.Brushes
     using Windows.UI.ViewManagement;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Media;
-    using Microsoft.AppCenter.Analytics;
     using Microsoft.Graphics.Canvas;
     using Microsoft.Graphics.Canvas.Effects;
     using Microsoft.Graphics.Canvas.UI.Composition;
     using Controls.Helpers;
+    using Notepads.Services;
 
     public sealed class HostBackdropAcrylicBrush : XamlCompositionBrushBase, IDisposable
     {
@@ -281,7 +281,7 @@ namespace Notepads.Brushes
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("FailedToBuildAcrylicBrushInternal",
+                AnalyticsService.TrackEvent("FailedToBuildAcrylicBrushInternal",
                     new Dictionary<string, string>
                     {
                         { "Exception", ex.ToString() },
@@ -329,7 +329,7 @@ namespace Notepads.Brushes
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("FailedToLoadImageBrush", new Dictionary<string, string> { { "Exception", ex.ToString() } });
+                AnalyticsService.TrackEvent("FailedToLoadImageBrush", new Dictionary<string, string> { { "Exception", ex.ToString() } });
                 return null;
             }
         }

--- a/src/Notepads/Controls/Dialog/FileRenameDialog.cs
+++ b/src/Notepads/Controls/Dialog/FileRenameDialog.cs
@@ -14,7 +14,6 @@ namespace Notepads.Controls.Dialog
     using Windows.UI.Xaml.Media;
     using Notepads.Services;
     using Notepads.Utilities;
-    using Microsoft.AppCenter.Analytics;
 
     public sealed class FileRenameDialog : NotepadsDialog
     {
@@ -68,7 +67,7 @@ namespace Notepads.Controls.Dialog
 
             PrimaryButtonClick += (sender, args) => TryRename();
 
-            Analytics.TrackEvent("FileRenameDialogOpened", new Dictionary<string, string>()
+            AnalyticsService.TrackEvent("FileRenameDialogOpened", new Dictionary<string, string>()
             {
                 { "FileExists", fileExists.ToString() },
             });

--- a/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
+++ b/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
@@ -5,7 +5,6 @@
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Commands;
     using Notepads.Controls.FindAndReplace;
     using Notepads.Controls.GoTo;
@@ -503,7 +502,7 @@
                 CloseSideBySideDiffViewer();
                 HideGoToControl();
                 FileReloaded?.Invoke(this, EventArgs.Empty);
-                Analytics.TrackEvent(encoding == null ? "OnFileReloaded" : "OnFileReopenedWithEncoding");
+                AnalyticsService.TrackEvent(encoding == null ? "OnFileReloaded" : "OnFileReopenedWithEncoding");
             }
         }
 
@@ -596,7 +595,7 @@
             SplitPanelColumnDefinition.MinWidth = 100.0f;
             SplitPanel.Visibility = Visibility.Visible;
             GridSplitter.Visibility = Visibility.Visible;
-            Analytics.TrackEvent("MarkdownContentPreview_Opened");
+            AnalyticsService.TrackEvent("MarkdownContentPreview_Opened");
             _isContentPreviewPanelOpened = true;
         }
 
@@ -646,7 +645,7 @@
             SideBySideDiffViewer.Visibility = Visibility.Visible;
             SideBySideDiffViewer.RenderDiff(LastSavedSnapshot.Content, TextEditorCore.GetText(), ThemeSettingsService.ThemeMode);
             SideBySideDiffViewer.Focus();
-            Analytics.TrackEvent("SideBySideDiffViewer_Opened");
+            AnalyticsService.TrackEvent("SideBySideDiffViewer_Opened");
         }
 
         public void CloseSideBySideDiffViewer()

--- a/src/Notepads/Controls/TextEditor/TextEditorCore.DuplicateText.cs
+++ b/src/Notepads/Controls/TextEditor/TextEditorCore.DuplicateText.cs
@@ -8,7 +8,6 @@ namespace Notepads.Controls.TextEditor
     using System;
     using System.Collections.Generic;
     using Windows.UI.Text;
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Services;
 
     public partial class TextEditorCore
@@ -69,7 +68,7 @@ namespace Notepads.Controls.TextEditor
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(TextEditorCore)}] Failed to duplicate text: {ex}");
-                Analytics.TrackEvent("TextEditorCore_FailedToDuplicateText",
+                AnalyticsService.TrackEvent("TextEditorCore_FailedToDuplicateText",
                     new Dictionary<string, string> { { "Exception", ex.ToString() } });
             }
         }

--- a/src/Notepads/Controls/TextEditor/TextEditorCore.JoinText.cs
+++ b/src/Notepads/Controls/TextEditor/TextEditorCore.JoinText.cs
@@ -8,7 +8,6 @@ namespace Notepads.Controls.TextEditor
     using System;
     using System.Collections.Generic;
     using Windows.UI.Text;
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Services;
 
     public partial class TextEditorCore
@@ -61,7 +60,7 @@ namespace Notepads.Controls.TextEditor
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(TextEditorCore)}] Failed to join text: {ex}");
-                Analytics.TrackEvent("TextEditorCore_FailedToJoinText",
+                AnalyticsService.TrackEvent("TextEditorCore_FailedToJoinText",
                     new Dictionary<string, string> { { "Exception", ex.ToString() } });
             }
         }

--- a/src/Notepads/Core/NotepadsCore.cs
+++ b/src/Notepads/Core/NotepadsCore.cs
@@ -28,7 +28,6 @@ namespace Notepads.Core
     using Windows.UI.Xaml.Controls;
     using Windows.UI.Xaml.Input;
     using Windows.UI.Xaml.Media;
-    using Microsoft.AppCenter.Analytics;
 
     public class NotepadsCore : INotepadsCore
     {
@@ -795,7 +794,7 @@ namespace Notepads.Core
                 }
 
                 deferral.Complete();
-                Analytics.TrackEvent("OnSetDropped");
+                AnalyticsService.TrackEvent("OnSetDropped");
             }
             catch (Exception ex)
             {

--- a/src/Notepads/Core/SessionManager.cs
+++ b/src/Notepads/Core/SessionManager.cs
@@ -16,7 +16,6 @@ namespace Notepads.Core
     using System.Threading.Tasks;
     using Windows.Storage;
     using Windows.Storage.AccessCache;
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Controls.TextEditor;
     using Notepads.Core.SessionDataModels;
     using Notepads.Models;
@@ -117,7 +116,7 @@ namespace Notepads.Core
                 catch (Exception ex)
                 {
                     LoggingService.LogError($"[{nameof(SessionManager)}] Failed to recover TextEditor: {ex.Message}");
-                    Analytics.TrackEvent("SessionManager_FailedToRecoverTextEditor", new Dictionary<string, string>() { { "Exception", ex.Message } });
+                    AnalyticsService.TrackEvent("SessionManager_FailedToRecoverTextEditor", new Dictionary<string, string>() { { "Exception", ex.Message } });
                     continue;
                 }
 
@@ -213,7 +212,7 @@ namespace Notepads.Core
                 catch (Exception ex)
                 {
                     LoggingService.LogError($"[{nameof(SessionManager)}] Failed to build TextEditor session data: {ex}");
-                    Analytics.TrackEvent("SessionManager_FailedToBuildTextEditorSessionData", new Dictionary<string, string>() { { "Exception", ex.Message } });
+                    AnalyticsService.TrackEvent("SessionManager_FailedToBuildTextEditorSessionData", new Dictionary<string, string>() { { "Exception", ex.Message } });
                 }
             }
 
@@ -237,7 +236,7 @@ namespace Notepads.Core
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(SessionManager)}] Failed to save session metadata: {ex.Message}");
-                Analytics.TrackEvent("SessionManager_FailedToSaveSessionMetaData", new Dictionary<string, string>() { { "Exception", ex.Message } });
+                AnalyticsService.TrackEvent("SessionManager_FailedToSaveSessionMetaData", new Dictionary<string, string>() { { "Exception", ex.Message } });
                 actionAfterSaving?.Invoke();
                 _semaphoreSlim.Release();
                 return; // Failed to save the session - do not proceed to delete backup files
@@ -251,7 +250,7 @@ namespace Notepads.Core
                 }
                 catch (Exception ex)
                 {
-                    Analytics.TrackEvent("SessionManager_FailedToDeleteOrphanedBackupFiles",
+                    AnalyticsService.TrackEvent("SessionManager_FailedToDeleteOrphanedBackupFiles",
                         new Dictionary<string, string>() { { "Exception", ex.Message } });
                 }
 
@@ -261,7 +260,7 @@ namespace Notepads.Core
                 }
                 catch (Exception ex)
                 {
-                    Analytics.TrackEvent("SessionManager_FailedToDeleteOrphanedTokensInFutureAccessList",
+                    AnalyticsService.TrackEvent("SessionManager_FailedToDeleteOrphanedTokensInFutureAccessList",
                         new Dictionary<string, string>() { { "Exception", ex.Message } });
                 }
             }
@@ -413,7 +412,7 @@ namespace Notepads.Core
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(SessionManager)}] Failed to delete session meta data: {ex.Message}");
-                Analytics.TrackEvent("SessionManager_FailedToDeleteSessionMetaData", new Dictionary<string, string>() { { "Exception", ex.Message } });
+                AnalyticsService.TrackEvent("SessionManager_FailedToDeleteSessionMetaData", new Dictionary<string, string>() { { "Exception", ex.Message } });
             }
         }
 
@@ -507,7 +506,7 @@ namespace Notepads.Core
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(SessionManager)}] Failed to save backup file: {ex.Message}");
-                Analytics.TrackEvent("SessionManager_FailedToSaveBackupFile", new Dictionary<string, string>() { { "Exception", ex.Message } });
+                AnalyticsService.TrackEvent("SessionManager_FailedToSaveBackupFile", new Dictionary<string, string>() { { "Exception", ex.Message } });
                 return false;
             }
         }
@@ -565,7 +564,7 @@ namespace Notepads.Core
                 catch (Exception ex)
                 {
                     LoggingService.LogError($"[{nameof(SessionManager)}] Failed to delete orphaned token in FutureAccessList: {ex.Message}");
-                    Analytics.TrackEvent("SessionManager_FailedToDeleteOrphanedTokenInFutureAccessList", new Dictionary<string, string>() { { "Exception", ex.Message } });
+                    AnalyticsService.TrackEvent("SessionManager_FailedToDeleteOrphanedTokenInFutureAccessList", new Dictionary<string, string>() { { "Exception", ex.Message } });
                 }
             }
         }

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -139,7 +139,6 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AppCenterSecret.cs" />
     <Compile Include="Commands\IMouseCommand.cs" />
     <Compile Include="Commands\IKeyboardCommand.cs" />
     <Compile Include="Commands\ICommandHandler.cs" />
@@ -178,6 +177,7 @@
     <Compile Include="Controls\TextEditor\TextEditorCore.MoveText.cs" />
     <Compile Include="Extensions\DispatcherExtensions.cs" />
     <Compile Include="Extensions\ScrollViewerExtensions.cs" />
+    <Compile Include="Services\AnalyticsService.cs" />
     <Compile Include="Utilities\FutureAccessListUtility.cs" />
     <Compile Include="Utilities\LanguageUtility.cs" />
     <Compile Include="Views\Settings\AboutPage.xaml.cs">
@@ -414,14 +414,11 @@
     <PackageReference Include="DiffPlex">
       <Version>1.7.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.AppCenter.Analytics">
-      <Version>5.0.5</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>5.0.5</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Services.Store.Engagement">
+      <Version>10.2307.3001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
       <Version>7.1.3</Version>
@@ -436,7 +433,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.4</Version>
+      <Version>9.0.2</Version>
     </PackageReference>
     <PackageReference Include="UTF.Unknown">
       <Version>2.5.1</Version>
@@ -454,17 +451,19 @@
   <ItemGroup>
     <None Include="Package.targets" />
   </ItemGroup>
+  <ItemGroup>
+    <SDKReference Include="Microsoft.Services.Store.Engagement, Version=10.0">
+      <Name>Microsoft Engagement Framework</Name>
+    </SDKReference>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015-2019 Runtime for Universal Windows Platform Apps</Name>
+    </SDKReference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <Import Project="Package.targets" />
-  <Target Name="AssignAppCenterSecret" BeforeTargets="BeforeBuild" Condition=" $(AppCenterSecret) != '' ">
-    <PropertyGroup>
-      <InputFile>AppCenterSecret.cs</InputFile>
-    </PropertyGroup>
-    <WriteLinesToFile File="$(InputFile)" Lines="$([System.IO.File]::ReadAllText($(InputFile)).Replace('AppCenterSecret = null','AppCenterSecret = &quot;$(AppCenterSecret)&quot;'))" Overwrite="true" Encoding="Unicode" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Notepads/Package.appxmanifest
+++ b/src/Notepads/Package.appxmanifest
@@ -11,7 +11,7 @@
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="mp uap uap5 uap10 desktop4 iot2 rescap">
   
-  <Identity Name="19282JackieLiu.Notepads-Beta" Publisher="CN=40E66D07-5A3A-4954-9CA3-A1EB15ED0804" Version="1.5.4.0" />
+  <Identity Name="19282JackieLiu.Notepads-Beta" Publisher="CN=40E66D07-5A3A-4954-9CA3-A1EB15ED0804" Version="1.5.6.0" />
   <mp:PhoneIdentity PhoneProductId="df234254-de03-48f0-80a0-11b5082ec740" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   
   <Properties>

--- a/src/Notepads/Services/AnalyticsService.cs
+++ b/src/Notepads/Services/AnalyticsService.cs
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------------------------------
+//  Copyright (c) 2019-2024, Jiaqi (0x7c13) Liu. All rights reserved.
+//  See LICENSE file in the project root for license information.
+// ---------------------------------------------------------------------------------------------
+
+namespace Notepads.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Services.Store.Engagement;
+
+    public static class AnalyticsService
+    {
+        private static StoreServicesCustomEventLogger Logger;
+
+        static AnalyticsService()
+        {
+            try
+            {
+                Logger = StoreServicesCustomEventLogger.GetDefault();
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+
+
+        public static void TrackEvent(string eventName, IDictionary<string, string> properties = null)
+        {
+            try
+            {
+                // TODO: Simplify this to use a single line, reduce complexity of properties by all the callers
+                //string eventMessage = properties != null
+                //    ? $"{eventName} - {Newtonsoft.Json.JsonConvert.SerializeObject(properties)}"
+                //    : eventName;
+                Logger?.Log(eventName);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+
+        public static void TrackError(Exception exception, IDictionary<string, string> properties = null)
+        {
+            try
+            {
+                Logger?.Log($"Error - {exception.Message} - {exception.StackTrace}");
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/src/Notepads/Services/MRUService.cs
+++ b/src/Notepads/Services/MRUService.cs
@@ -10,7 +10,6 @@ namespace Notepads.Services
     using System.Threading.Tasks;
     using Windows.Storage;
     using Windows.Storage.AccessCache;
-    using Microsoft.AppCenter.Analytics;
 
     public static class MRUService
     {
@@ -24,7 +23,7 @@ namespace Notepads.Services
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("MRUService_FailedToAddStorageItemToMRU", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("MRUService_FailedToAddStorageItemToMRU", new Dictionary<string, string>()
                 {
                     { "Exception", ex.ToString() }
                 });
@@ -58,7 +57,7 @@ namespace Notepads.Services
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("MRUService_FailedToGetMRU", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("MRUService_FailedToGetMRU", new Dictionary<string, string>()
                 {
                     { "Exception", ex.ToString() }
                 });
@@ -75,7 +74,7 @@ namespace Notepads.Services
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("MRUService_FailedToClearMRU", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("MRUService_FailedToClearMRU", new Dictionary<string, string>()
                 {
                     { "Exception", ex.ToString() }
                 });

--- a/src/Notepads/Services/NotepadsProtocolService.cs
+++ b/src/Notepads/Services/NotepadsProtocolService.cs
@@ -8,7 +8,6 @@ namespace Notepads.Services
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Microsoft.AppCenter.Analytics;
     using Windows.ApplicationModel;
     using Windows.System;
 
@@ -50,7 +49,7 @@ namespace Notepads.Services
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(NotepadsProtocolService)}] Failed to parse protocol: {uri}, exception: {ex}");
-                Analytics.TrackEvent("NotepadsProtocolService_FailedToParseProtocol", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("NotepadsProtocolService_FailedToParseProtocol", new Dictionary<string, string>()
                 {
                     { "Protocol", uri.ToString() },
                     { "Exception", ex.ToString() }
@@ -82,7 +81,7 @@ namespace Notepads.Services
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(NotepadsProtocolService)}] Failed to execute protocol: {operation}, Exception: {ex}");
-                Analytics.TrackEvent("NotepadsProtocolService_FailedToExecuteProtocol", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("NotepadsProtocolService_FailedToExecuteProtocol", new Dictionary<string, string>()
                 {
                     { "Protocol", operation.ToString() },
                     { "Exception", ex.Message }

--- a/src/Notepads/Utilities/BrushUtility.cs
+++ b/src/Notepads/Utilities/BrushUtility.cs
@@ -11,9 +11,9 @@ namespace Notepads.Utilities
     using System.Threading.Tasks;
     using Windows.UI;
     using Windows.UI.Xaml.Media;
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Brushes;
     using Notepads.Extensions;
+    using Notepads.Services;
 
     public static class BrushUtility
     {
@@ -34,7 +34,7 @@ namespace Notepads.Utilities
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("FailedToCreateAcrylicBrush", new Dictionary<string, string>
+                AnalyticsService.TrackEvent("FailedToCreateAcrylicBrush", new Dictionary<string, string>
                 {
                     { "Exception", ex.ToString() },
                     { "Message", ex.Message },

--- a/src/Notepads/Utilities/DialogManager.cs
+++ b/src/Notepads/Utilities/DialogManager.cs
@@ -9,8 +9,8 @@ namespace Notepads.Utilities
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Notepads.Controls.Dialog;
+    using Notepads.Services;
     using Windows.UI.Xaml.Controls;
-    using Microsoft.AppCenter.Analytics;
 
     public static class DialogManager
     {
@@ -36,7 +36,7 @@ namespace Notepads.Utilities
                 {
                     pendingDialogTitle = pendingTitle;
                 }
-                Analytics.TrackEvent("FailedToOpenDialog", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("FailedToOpenDialog", new Dictionary<string, string>()
                 {
                     { "Message", ex.Message },
                     { "Exception", ex.ToString() },

--- a/src/Notepads/Utilities/EncodingUtility.cs
+++ b/src/Notepads/Utilities/EncodingUtility.cs
@@ -10,7 +10,7 @@ namespace Notepads.Utilities
     using System.Collections.Generic;
     using System.Text;
     using System.Threading;
-    using Microsoft.AppCenter.Analytics;
+    using Notepads.Services;
 
     public static class EncodingUtility
     {
@@ -127,7 +127,7 @@ namespace Notepads.Utilities
                 try
                 {
                     encodingName = encoding.WebName; // WebName is supported by Encoding.GetEncoding(WebName)
-                    Analytics.TrackEvent("EncodingUtility_FoundUnlistedEncoding", new Dictionary<string, string>()
+                    AnalyticsService.TrackEvent("EncodingUtility_FoundUnlistedEncoding", new Dictionary<string, string>()
                     {
                         {"CodePage", encoding.CodePage.ToString()},
                         {"WebName", encoding.WebName}
@@ -135,7 +135,7 @@ namespace Notepads.Utilities
                 }
                 catch (Exception ex)
                 {
-                    Analytics.TrackEvent("EncodingUtility_FailedToGetNameOfUnlistedEncoding", new Dictionary<string, string>()
+                    AnalyticsService.TrackEvent("EncodingUtility_FailedToGetNameOfUnlistedEncoding", new Dictionary<string, string>()
                     {
                         {"Exception", ex.ToString()},
                         {"Message", ex.Message}
@@ -217,7 +217,7 @@ namespace Notepads.Utilities
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("EncodingUtility_FailedToGetEncoding", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("EncodingUtility_FailedToGetEncoding", new Dictionary<string, string>()
                 {
                     {"EncodingName", name},
                     {"Exception", ex.ToString()}
@@ -243,7 +243,7 @@ namespace Notepads.Utilities
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("EncodingUtility_FailedToGetSystemDefaultANSIEncoding", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("EncodingUtility_FailedToGetSystemDefaultANSIEncoding", new Dictionary<string, string>()
                 {
                     { "Message", ex.Message },
                     { "Exception", ex.ToString() },
@@ -270,7 +270,7 @@ namespace Notepads.Utilities
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("EncodingUtility_FailedToGetCurrentCultureANSIEncoding", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("EncodingUtility_FailedToGetCurrentCultureANSIEncoding", new Dictionary<string, string>()
                 {
                     { "Message", ex.Message },
                     { "Exception", ex.ToString() },
@@ -300,7 +300,7 @@ namespace Notepads.Utilities
                 }
                 catch (Exception ex)
                 {
-                    Analytics.TrackEvent("EncodingUtility_FailedToGetANSIEncoding", new Dictionary<string, string>()
+                    AnalyticsService.TrackEvent("EncodingUtility_FailedToGetANSIEncoding", new Dictionary<string, string>()
                     {
                         { "Message", ex.Message },
                         { "Exception", ex.ToString() },

--- a/src/Notepads/Utilities/FileSystemUtility.cs
+++ b/src/Notepads/Utilities/FileSystemUtility.cs
@@ -5,7 +5,6 @@
 
 namespace Notepads.Utilities
 {
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Models;
     using Notepads.Services;
     using System;
@@ -454,12 +453,12 @@ namespace Notepads.Utilities
                 }
                 else if (stream.Length > 0) // We do not care about empty file
                 {
-                    Analytics.TrackEvent("UnableToDetectEncoding");
+                    AnalyticsService.TrackEvent("UnableToDetectEncoding");
                 }
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("TryGuessEncodingFailedWithException", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("TryGuessEncodingFailedWithException", new Dictionary<string, string>()
                 {
                     { "Exception", ex.ToString() },
                     { "Message", ex.Message }
@@ -682,7 +681,7 @@ namespace Notepads.Utilities
                 {
                     // Track retry attempts to better understand the failed scenarios
                     // File name, path and content are not included to respect/protect user privacy
-                    Analytics.TrackEvent(operationName, new Dictionary<string, string>()
+                    AnalyticsService.TrackEvent(operationName, new Dictionary<string, string>()
                     {
                         { "RetryAttempts", retryAttempts.ToString() },
                         { "DeferUpdatesUsed" , deferUpdatesUsed.ToString() },
@@ -702,7 +701,7 @@ namespace Notepads.Utilities
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(FileSystemUtility)}] Failed to get or create file, Exception: {ex.Message}");
-                Analytics.TrackEvent("GetOrCreateFileAsync_Failed", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("GetOrCreateFileAsync_Failed", new Dictionary<string, string>()
                 {
                     { "Exception", ex.ToString() },
                 });

--- a/src/Notepads/Utilities/FontUtility.cs
+++ b/src/Notepads/Utilities/FontUtility.cs
@@ -13,7 +13,7 @@ namespace Notepads.Utilities
     using Windows.UI.Text;
     using Windows.UI.Xaml.Controls;
     using Windows.UI.Xaml.Media;
-    using Microsoft.AppCenter.Analytics;
+    using Notepads.Services;
 
     public static class FontUtility
     {
@@ -144,7 +144,7 @@ namespace Notepads.Utilities
             }
             catch (Exception ex)
             {
-                Analytics.TrackEvent("FailedToGetSystemFontFamilies", new Dictionary<string, string>()
+                AnalyticsService.TrackEvent("FailedToGetSystemFontFamilies", new Dictionary<string, string>()
                 {
                     { "Exception", ex.ToString() }
                 });

--- a/src/Notepads/Utilities/FutureAccessListUtility.cs
+++ b/src/Notepads/Utilities/FutureAccessListUtility.cs
@@ -10,7 +10,6 @@ namespace Notepads.Utilities
     using System.Threading.Tasks;
     using Windows.Storage;
     using Windows.Storage.AccessCache;
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Services;
 
     public static class FutureAccessListUtility
@@ -44,7 +43,7 @@ namespace Notepads.Utilities
             catch (Exception ex)
             {
                 LoggingService.LogError($"[{nameof(FutureAccessListUtility)}] Failed to add file [{file.Path}] to future access list: {ex.Message}");
-                Analytics.TrackEvent("FailedToAddTokenInFutureAccessList",
+                AnalyticsService.TrackEvent("FailedToAddTokenInFutureAccessList",
                     new Dictionary<string, string>()
                     {
                         { "ItemCount", GetFutureAccessListItemCount().ToString() },

--- a/src/Notepads/Views/MainPage/NotepadsMainPage.IO.cs
+++ b/src/Notepads/Views/MainPage/NotepadsMainPage.IO.cs
@@ -17,7 +17,6 @@ namespace Notepads.Views.MainPage
     using Notepads.Controls.TextEditor;
     using Notepads.Services;
     using Notepads.Utilities;
-    using Microsoft.AppCenter.Analytics;
 
     public sealed partial class NotepadsMainPage
     {
@@ -106,7 +105,7 @@ namespace Notepads.Views.MainPage
                     {
                         extension = "<NoExtension>";
                     }
-                    Analytics.TrackEvent("UnsupportedFileExtension", new Dictionary<string, string>()
+                    AnalyticsService.TrackEvent("UnsupportedFileExtension", new Dictionary<string, string>()
                     {
                         { "Extension", extension },
                     });

--- a/src/Notepads/Views/MainPage/NotepadsMainPage.ViewModes.cs
+++ b/src/Notepads/Views/MainPage/NotepadsMainPage.ViewModes.cs
@@ -8,7 +8,6 @@ namespace Notepads.Views.MainPage
     using System;
     using Windows.UI.ViewManagement;
     using Windows.UI.Xaml;
-    using Microsoft.AppCenter.Analytics;
     using Notepads.Services;
     using Windows.Foundation;
 
@@ -57,7 +56,7 @@ namespace Notepads.Views.MainPage
                 if (!modeSwitched)
                 {
                     LoggingService.LogError($"[{nameof(NotepadsMainPage)}] Failed to enter CompactOverlay view mode.");
-                    Analytics.TrackEvent("FailedToEnterCompactOverlayViewMode");
+                    AnalyticsService.TrackEvent("FailedToEnterCompactOverlayViewMode");
                 }
             }
             else if (ApplicationView.GetForCurrentView().ViewMode == ApplicationViewMode.CompactOverlay)
@@ -67,7 +66,7 @@ namespace Notepads.Views.MainPage
                 if (!modeSwitched)
                 {
                     LoggingService.LogError($"[{nameof(NotepadsMainPage)}] Failed to enter Default view mode.");
-                    Analytics.TrackEvent("FailedToEnterDefaultViewMode");
+                    AnalyticsService.TrackEvent("FailedToEnterDefaultViewMode");
                 }
             }
         }
@@ -92,7 +91,7 @@ namespace Notepads.Views.MainPage
                 else
                 {
                     LoggingService.LogError($"[{nameof(NotepadsMainPage)}] Failed to enter full screen view mode.");
-                    Analytics.TrackEvent("FailedToEnterFullScreenViewMode");
+                    AnalyticsService.TrackEvent("FailedToEnterFullScreenViewMode");
                 }
             }
         }

--- a/src/Notepads/Views/MainPage/NotepadsMainPage.xaml.cs
+++ b/src/Notepads/Views/MainPage/NotepadsMainPage.xaml.cs
@@ -30,7 +30,6 @@ namespace Notepads.Views.MainPage
     using Windows.UI.Xaml.Input;
     using Windows.UI.Xaml.Media.Animation;
     using Windows.UI.Xaml.Navigation;
-    using Microsoft.AppCenter.Analytics;
     using Windows.Graphics.Printing;
 
     public sealed partial class NotepadsMainPage : Page
@@ -170,7 +169,7 @@ namespace Notepads.Views.MainPage
         {
             if (!await NotepadsProtocolService.LaunchProtocolAsync(NotepadsOperationProtocol.OpenNewInstance))
             {
-                Analytics.TrackEvent("FailedToOpenNewAppInstance");
+                AnalyticsService.TrackEvent("FailedToOpenNewAppInstance");
             }
         }
 
@@ -222,7 +221,7 @@ namespace Notepads.Views.MainPage
 
                     LoggingService.LogInfo($"[{nameof(NotepadsMainPage)}] {numberOfRecoveredFiles} file(s) recovered from last session backup.");
 
-                    Analytics.TrackEvent("SessionManager_FailedToLoadLastSession_SessionDataCorruptedException",
+                    AnalyticsService.TrackEvent("SessionManager_FailedToLoadLastSession_SessionDataCorruptedException",
                         new Dictionary<string, string>()
                         {
                             { "Exception", ex.Message },
@@ -243,7 +242,7 @@ namespace Notepads.Views.MainPage
                 catch (Exception ex) // Catch all other exceptions
                 {
                     LoggingService.LogError($"[{nameof(NotepadsMainPage)}] Failed to load last session: {ex}");
-                    Analytics.TrackEvent("SessionManager_FailedToLoadLastSession_UnhandledException", new Dictionary<string, string>() { { "Exception", ex.Message } });
+                    AnalyticsService.TrackEvent("SessionManager_FailedToLoadLastSession_UnhandledException", new Dictionary<string, string>() { { "Exception", ex.Message } });
                 }
             }
 
@@ -507,7 +506,7 @@ namespace Notepads.Views.MainPage
                 {
                     if (!await ApplicationView.GetForCurrentView().TryConsolidateAsync())
                     {
-                        Analytics.TrackEvent("FailedToConsolidateOnExit");
+                        AnalyticsService.TrackEvent("FailedToConsolidateOnExit");
                     }
 
                     Application.Current.Exit();
@@ -621,7 +620,7 @@ namespace Notepads.Views.MainPage
                 if (storageItem is StorageFile file)
                 {
                     await OpenFileAsync(file);
-                    Analytics.TrackEvent("OnStorageFileDropped");
+                    AnalyticsService.TrackEvent("OnStorageFileDropped");
                 }
             }
         }


### PR DESCRIPTION
Deprecate Microsoft.AppCenter since it is scheduled for retirement on March 31, 2025

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
Remove Microsoft.AppCenter analytics.

## Other information
